### PR TITLE
Update submit-SLURM-job.in

### DIFF
--- a/src/services/a-rex/lrms/slurm/submit-SLURM-job.in
+++ b/src/services/a-rex/lrms/slurm/submit-SLURM-job.in
@@ -114,7 +114,7 @@ fi
 echo "SLURM jobname: $jobname" 1>&2
 # Set up the user's environment on the compute node where the script
 # is executed.
-echo "#SBATCH --get-user-env=10L" >> $LRMS_JOB_SCRIPT
+echo "#SBATCH --get-user-env" >> $LRMS_JOB_SCRIPT
 
 ##############################################################
 # (non-)parallel jobs


### PR DESCRIPTION
Remove the argument on `--get-user-env` as SLURM 25.05.xx no longer supports arguments here at all.

The commit at https://github.com/nordugrid/arc/commit/d4b9aef8d4a29911ad03a7ba84083acc40e98815 looks to try and resolve this however it still fails on submission.