### PR TITLE
Handle Python multi-phase initialization support in swig-4.4.0

### DIFF
--- a/python/swigmodulesinit_wrap.cpp
+++ b/python/swigmodulesinit_wrap.cpp
@@ -29,18 +29,53 @@ PyMODINIT_FUNC SWIG_init(data)(void);
 PyMODINIT_FUNC SWIG_init(delegation)(void);
 PyMODINIT_FUNC SWIG_init(security)(void);
 
+/* Legacy init based on https://peps.python.org/pep-0489/ */
+static PyObject *module_legacy_init(PyModuleDef *def) {
+  PyModuleDef_Slot *slots = def->m_slots;
+  def->m_slots = NULL;
+  PyObject *mod = PyModule_Create(def);
+  while (mod && slots->slot) {
+    if (slots->slot == Py_mod_exec) {
+      int (*mod_exec)(PyObject *) = (int (*)(PyObject *))slots->value;
+      if (mod_exec(mod) != 0) {
+        Py_DECREF(mod);
+        mod = NULL;
+      }
+    }
+    ++slots;
+  }
+  return mod;
+}
+
 static PyMODVAL init_extension_module(PyObject* package, const char *modulename,
 PyMODVAL (*initfunction)(void)) {
 #if PY_MAJOR_VERSION >= 3
-  PyObject *module = initfunction();
+  // swig-4.4.0 implements PEP-489 multi-phase initialization.
+  // Handle both old single-phase and new multi-phase initialization.
+  // Modules that use multi-phase initialization will return a PyModuleDef, so then we force a legacy single-phase initialization.
+  PyObject *module_or_module_def = initfunction();
+  if (!module_or_module_def) {
+    fprintf(stderr, "Failed first phase initializing Python module '%s', through Python C API\n", modulename);
+    PyMOD_RETURN(NULL);
+  }
+  PyObject *module = NULL;
+  if (PyObject_TypeCheck(module_or_module_def, &PyModuleDef_Type)) {
+    module = module_legacy_init((PyModuleDef *)module_or_module_def);
+    if (!module) {
+      fprintf(stderr, "Failed second phase initializing Python module '%s', through Python C API\n", modulename);
+      PyMOD_RETURN(NULL);
+    }
+  } else {
+    module = module_or_module_def;
+  }
 #else
   initfunction();
   PyObject *module = PyImport_AddModule((char *)modulename);
-#endif
   if(!module) {
     fprintf(stderr, "Failed initialising Python module '%s', through Python C API\n", modulename);
     PyMOD_RETURN(NULL);
   }
+#endif
   if(PyModule_AddObject(package, (char *)modulename, module)) {
     fprintf(stderr, "Failied adding Python module '%s' to package 'arc', through Python C API\n", modulename);
     PyMOD_RETURN(NULL);


### PR DESCRIPTION
Fixes problem reported in https://github.com/swig/swig/issues/3266.

Fix is implemented to support original Python single-phase module initialization that swig-4.3.1 and earlier generated as well as the new multi-phase module initialization that swig-4.0.0 generates. Arc subverts the normal module initialization by manually initializing other modules (common, loader message, communication, etc), during the initialization of arc. These other modules are also generated by SWIG for multi-phase initialization by the Python interpreter. The manual initialization by arc breaks and is worked around by implementing the 'legacy initialization' approach documented in PEP-489 https://peps.python.org/pep-0489/. This is not really standard as the legacy single-phase initialization is implemented even though SWIG has already started the multi-phase initialization. This is achieved by setting m_slots in PyModuleDef to NULL and manually calling the Py_mod_exec function in the slot to complete the second phase of the initialization.

While this might work for now, a future proof approach would be for each of the modules to be initialized by the Python interpreter in the standard way by using proper sub-modules under a top level arc module/package.