### PR TITLE
Run time environment.py fixes

### DIFF
--- a/src/utils/python/arc/control/RunTimeEnvironment.py
+++ b/src/utils/python/arc/control/RunTimeEnvironment.py
@@ -55,7 +55,7 @@ class RTEControl(ComponentControl):
         if self.user_rte_dirs is None:
             self.user_rte_dirs = []
         # define internal structures to hold RTEs
-        self.all_rtes = {}
+        self.all_rtes = None
         self.system_rtes = {}
         self.user_rtes = {}
         self.community_rtes = {}
@@ -109,8 +109,9 @@ class RTEControl(ComponentControl):
     def __fetch_rtes(self):
         """Look for RTEs on the filesystem and fill the object structures"""
         # run once per tool invocation
-        if self.all_rtes:
+        if self.all_rtes is not None:
             return
+
         # available pre-installed RTEs
         self.logger.debug('Indexing ARC defined RTEs from %s', self.system_rte_dir)
         self.system_rtes = self.get_dir_rtes(self.system_rte_dir)
@@ -126,7 +127,7 @@ class RTEControl(ComponentControl):
             self.user_rtes.update(rtes)
 
         # all available RTEs
-        self.all_rtes.update(self.system_rtes)
+        self.all_rtes = self.system_rtes.copy()
         self.all_rtes.update(self.user_rtes)
 
         # Community-defined RTEs
@@ -175,6 +176,7 @@ class RTEControl(ComponentControl):
 
     def __get_rte_list(self, rtes, check_dict=None):
         rte_list = []
+        # BEWARE! self.all_rtes used without self.__fetch_rtes() first
         if check_dict is None:
             check_dict = self.all_rtes
         for r in rtes:

--- a/src/utils/python/arc/control/RunTimeEnvironment.py
+++ b/src/utils/python/arc/control/RunTimeEnvironment.py
@@ -409,11 +409,12 @@ class RTEControl(ComponentControl):
 
     def params_set(self, rte, parameter, value, use_default=False):
         params = self.__params_parse(rte)
-        if parameter not in params:
+        pdescr = params.get(parameter)
+        if pdescr is None:
             # allowed to set undocumented parameters? force option?
             self.logger.error('There is no such parameter %s for RunTimeEnvironment %s', parameter, rte)
             sys.exit(1)
-        if params[parameter]['set'] > 2:
+        if pdescr['set'] > 2:
             if value is None:
                 self.logger.warning('Clearing undocumented parameter %s for RunTimeEnvironment %s', parameter, rte)
             else:
@@ -423,21 +424,21 @@ class RTEControl(ComponentControl):
         else:
             # use default value if requested
             if use_default:
-                value = params[parameter]['default_value']
+                value = pdescr['default_value']
             # check type and allowed values
-            if params[parameter]['allowed_string'] == 'string':
+            if pdescr['allowed_string'] == 'string':
                 pass
-            elif params[parameter]['allowed_string'] == 'int':
+            elif pdescr['allowed_string'] == 'int':
                 if not re.match(r'[-0-9]+', value):
                     self.logger.error('Parameter %s for RunTimeEnvironment %s should be integer', parameter, rte)
                     sys.exit(1)
-            elif value not in params[parameter]['allowed_values']:
+            elif value not in pdescr['allowed_values']:
                 self.logger.error('Parameter %s for RunTimeEnvironment %s should be one of %s',
-                                  parameter, rte, params[parameter]['allowed_string'])
+                                  parameter, rte, pdescr['allowed_string'])
                 sys.exit(1)
         # assign new value
-        params[parameter]['value'] = value
-        params[parameter]['set'] = 2 if value is not None else 0
+        pdescr['value'] = value
+        pdescr['set'] = 2 if value is not None else 0
         self.__params_write(rte, params)
 
     def cat_rte(self, rte):

--- a/src/utils/python/arc/control/RunTimeEnvironment.py
+++ b/src/utils/python/arc/control/RunTimeEnvironment.py
@@ -5,7 +5,7 @@ from .ControlCommon import *
 import sys
 import re
 import fnmatch
-from itertools import chain
+from itertools import chain, islice
 
 try:
     from .CommunityRTE import CommunityRTEControl
@@ -83,15 +83,11 @@ class RTEControl(ComponentControl):
             return 'Dummy RTE for information publishing'
         descr_match = re.compile(r'#+\s*description:\s*(.*?)\s*$', flags=re.IGNORECASE).match
         with open(rte_path) as rte_f:
-            max_lines = 10
             description = 'RTE description is Not Available'
-            for line in rte_f:
+            for line in islice(rte_f, 10):
                 descr_re = descr_match(line)
                 if descr_re:
                     description = descr_re.group(1)
-                max_lines -= 1
-                if not max_lines:
-                    break
             return description
 
     @staticmethod
@@ -314,8 +310,7 @@ class RTEControl(ComponentControl):
         param_match = re.compile(r'#\s*param:([^:]+):([^:]+):([^:]*):(.*)$').match
         params = {}
         with open(rte_file) as rte_f:
-            max_lines = 20
-            for line in rte_f:
+            for line in islice(rte_f, 20):
                 param_re = param_match(line)
                 if param_re:
                     pname = param_re.group(1)
@@ -328,9 +323,6 @@ class RTEControl(ComponentControl):
                         'description': param_re.group(4),
                         'set': 0,
                     }
-                max_lines -= 1
-                if not max_lines:
-                    break
         params_defined = self.__params_read(rte)
         for pname, value in params_defined.items():
             if pname in params:

--- a/src/utils/python/arc/control/RunTimeEnvironment.py
+++ b/src/utils/python/arc/control/RunTimeEnvironment.py
@@ -81,11 +81,12 @@ class RTEControl(ComponentControl):
     def get_rte_description(rte_path):
         if rte_path == '/dev/null':
             return 'Dummy RTE for information publishing'
+        descr_match = re.compile(r'#+\s*description:\s*(.*?)\s*$', flags=re.IGNORECASE).match
         with open(rte_path) as rte_f:
             max_lines = 10
             description = 'RTE description is Not Available'
             for line in rte_f:
-                descr_re = re.match(r'^#+\s*description:\s*(.*)\s*$', line, flags=re.IGNORECASE)
+                descr_re = descr_match(line)
                 if descr_re:
                     description = descr_re.group(1)
                 max_lines -= 1
@@ -308,12 +309,12 @@ class RTEControl(ComponentControl):
 
     def __params_parse(self, rte):
         rte_file = self.__get_rte_file(rte)
-        param_str = re.compile(r'#\s*param:([^:]+):([^:]+):([^:]*):(.*)$')
+        param_match = re.compile(r'#\s*param:([^:]+):([^:]+):([^:]*):(.*)$').match
         params = {}
         with open(rte_file) as rte_f:
             max_lines = 20
             for line in rte_f:
-                param_re = param_str.match(line)
+                param_re = param_match(line)
                 if param_re:
                     pname = param_re.group(1)
                     params[pname] = {
@@ -347,10 +348,10 @@ class RTEControl(ComponentControl):
         rte_params_file = self.__get_rte_params_file(rte + suffix)
         params = {}
         if rte_params_file:
-            kv_re = re.compile(r'^([^ =]+)="(.*)"\s*$')
+            kv_match = re.compile(r'([^ =]+)="(.*)"\s*$').match
             with open(rte_params_file) as rte_parm_f:
                 for line in rte_parm_f:
-                    kv = kv_re.match(line)
+                    kv = kv_match(line)
                     if kv:
                         params[kv.group(1)] = kv.group(2)
         return params
@@ -429,7 +430,8 @@ class RTEControl(ComponentControl):
             if pdescr['allowed_string'] == 'string':
                 pass
             elif pdescr['allowed_string'] == 'int':
-                if not re.match(r'[-0-9]+', value):
+                # XXX - regex should really be pre-compiled
+                if not re.match(r'-?[0-9]+$', value):
                     self.logger.error('Parameter %s for RunTimeEnvironment %s should be integer', parameter, rte)
                     sys.exit(1)
             elif value not in pdescr['allowed_values']:

--- a/src/utils/python/arc/control/RunTimeEnvironment.py
+++ b/src/utils/python/arc/control/RunTimeEnvironment.py
@@ -322,14 +322,24 @@ class RTEControl(ComponentControl):
                         'allowed_values': param_re.group(2).split(','),
                         'default_value': param_re.group(3),
                         'value': param_re.group(3),
-                        'description': param_re.group(4)
+                        'description': param_re.group(4),
+                        'set': 0,
                     }
-                    params_defined = self.__params_read(rte)
-                    if pname in params_defined:
-                        params[pname]['value'] = params_defined[pname]
                 max_lines -= 1
                 if not max_lines:
                     break
+        params_defined = self.__params_read(rte)
+        for pname, value in params_defined.items():
+            if pname in params:
+                params[pname]['set'] = 1
+            else:
+                self.logger.warning('Undocumented parameter %s with value %s for RunTimeEnvironment %s', pname, value, rte)
+                params[pname] = {
+                    'name': pname,
+                    # XXX - should we use a different value here?
+                    'set': 3,
+                }
+            params[pname]['value'] = value
         return params
 
     def __params_read(self, rte, suffix=''):
@@ -361,7 +371,8 @@ class RTEControl(ComponentControl):
         try:
             with open(rte_params_file, 'w') as rte_parm_f:
                 for p in params.values():
-                    rte_parm_f.write('{name}="{value}"\n'.format(**p))
+                    if p['set']:
+                        rte_parm_f.write('{name}="{value}"\n'.format(**p))
         except EnvironmentError as err:
             self.logger.error('Failed to write RTE parameters file %s. Error: %s', rte_params_file, str(err))
             sys.exit(1)
@@ -374,10 +385,13 @@ class RTEControl(ComponentControl):
                 # set strings for undefined values output
                 if pdescr['value'] == '':
                     pdescr['value'] = 'undefined'
-                if pdescr['default_value'] == '':
-                    pdescr['default_value'] = 'undefined'
-                print('{name:>16} = {value:10} {description} (default is {default_value}) '
-                      '(allowed values are: {allowed_string})'.format(**pdescr))
+                if pdescr['set'] < 3:
+                    if pdescr['default_value'] == '':
+                        pdescr['default_value'] = 'undefined'
+                    print('{name:>16} = {value:10} {description} (default is {default_value}) '
+                          '(allowed values are: {allowed_string})'.format(**pdescr))
+                else:
+                    print('{name:>16} = {value:10} [UNDOCUMENTED PARAMETER]'.format(**pdescr))
             else:
                 print('{name}={value}'.format(**pdescr))
         # community software deployment (read-only) params
@@ -391,29 +405,39 @@ class RTEControl(ComponentControl):
                 print(fstring.format(k, cparams[k]))
 
     def params_unset(self, rte, parameter):
-        self.params_set(rte, parameter, None, use_default=True)
+        self.params_set(rte, parameter, None)
 
     def params_set(self, rte, parameter, value, use_default=False):
         params = self.__params_parse(rte)
         if parameter not in params:
+            # allowed to set undocumented parameters? force option?
             self.logger.error('There is no such parameter %s for RunTimeEnvironment %s', parameter, rte)
             sys.exit(1)
-        # use default value if requested
-        if use_default:
-            value = params[parameter]['default_value']
-        # check type and allowed values
-        if params[parameter]['allowed_string'] == 'string':
-            pass
-        elif params[parameter]['allowed_string'] == 'int':
-            if not re.match(r'[-0-9]+', value):
-                self.logger.error('Parameter %s for RunTimeEnvironment %s should be integer', parameter, rte)
+        if params[parameter]['set'] > 2:
+            if value is None:
+                self.logger.warning('Clearing undocumented parameter %s for RunTimeEnvironment %s', parameter, rte)
+            else:
+                # allowed to set undocumented parameters? force option?
+                self.logger.error('There is no such parameter %s for RunTimeEnvironment %s', parameter, rte)
                 sys.exit(1)
-        elif value not in params[parameter]['allowed_values']:
-            self.logger.error('Parameter %s for RunTimeEnvironment %s should be one of %s',
-                              parameter, rte, params[parameter]['allowed_string'])
-            sys.exit(1)
+        else:
+            # use default value if requested
+            if use_default:
+                value = params[parameter]['default_value']
+            # check type and allowed values
+            if params[parameter]['allowed_string'] == 'string':
+                pass
+            elif params[parameter]['allowed_string'] == 'int':
+                if not re.match(r'[-0-9]+', value):
+                    self.logger.error('Parameter %s for RunTimeEnvironment %s should be integer', parameter, rte)
+                    sys.exit(1)
+            elif value not in params[parameter]['allowed_values']:
+                self.logger.error('Parameter %s for RunTimeEnvironment %s should be one of %s',
+                                  parameter, rte, params[parameter]['allowed_string'])
+                sys.exit(1)
         # assign new value
         params[parameter]['value'] = value
+        params[parameter]['set'] = 2 if value is not None else 0
         self.__params_write(rte, params)
 
     def cat_rte(self, rte):


### PR DESCRIPTION
The primary purpose of this merge request is to avoid writing down
default values into the params file for the RTEs. Writing down the
default is a problem because it locks down a default even if no one
has even chosen them. This becomes a problem if the default changes.
The RTE will then stay with the old default (which may or may not
work). And some extreme cases when the RTE meta-data is not in sync
with the actual code it can become much worse (see nordugrid bug
#4288), where the RTE worked until an unrelated parameter is
changed and suddenly a parameter not changed was changed!

It will now also show keys and values that are not documented with
RTE meta-data. It will complain about them but they will be shown.
This is particularly good if/when parameters are removed/renamed.

One can now see these key/values and decide if they are actually
needed (probably not) or should be removed (much more probable).
And one can now easily remove them with arcctl rte params-unset.
arcctl will complain twice about it put will happily do it!

What *can't* be done is setting an undocumented parameter! This
is either a feature or not.

When consequence of this merge request is that when one unsets a
parameter with arcctl param-unset it will now delete the parameter from
the params-file. Which sort of better matches the verb in the command.
It still will lead to the RTE using the default value, since the code
still will use the default value if it is not set in the params-file.

But there is no longer any easy way to *set* the value to the default
value. With this merge request one way to do it requires two commands,
arcctl rte params-get -l too see the default value and then copy and
paste that value to an arcctl rte params-set command. Maybe there should
be a way to do this directly?

Some of the parsing for the params-file might still be a bit optimistic(?). This might be me not knowing what actually works in the
params-file for the RTE. Is it parsed by ARC-code or simple sourced by
a bourne shell? If it is parsed by ARC-code it is mostly no problems
but if sourced by bourne shell there all fun things to consider.
What if the value is not enclosed in double quotes?
 FOO=12
 BAR='*/1'
Both these values are invisible to arcctl? Except for arcctl rte cat.
What if we do strange shell things?
 FOO="123" sleep 0""
According to arcctl params-get FOO is '123" sleep"' but that is not
true! At all. It is in fact not even set.
How about?
 true;FOO="bar"
arcctl thinks this is setting "true;FOO" to "bar".
And this is just parsing the params-file. Then there is the issue of
parsing parameters to params-set. What happens if one does?
  arcctl rte params-set RTE key 'foo"'
At best the key will be ignored at worst the RTE will fail hard.

I wish I had a nice solution for this but the best I can come up with
is being stricter in the parsing of the params-file and stricter in what is allowed to params-set/params-unset. But then, how does the RTE actually get parsed when being used?

So that is it. I hope you understand this request and find at least the
idea of it useful. 